### PR TITLE
added geolocation functionality

### DIFF
--- a/assets/javascript/catalogue.js
+++ b/assets/javascript/catalogue.js
@@ -128,7 +128,7 @@ function likeHandler() {
 
   //check whether we have sufficient data to proceed to cat select page
   if (haveEnoughData()) {
-    searchForCats();
+    getGeolocation();
   } else {
     //select a photo to show next and update DOM with new photo
     tempCatArray = catLibrary;


### PR DESCRIPTION
Added functionality to get user's geolocation and incorporate it into the petfinder search.  I put the geolocation prompt at the end of the catalogue step, so the likeHandler function in catalogue.js now calls getGeolocation rather than searchForCats when it's ready to proceed to the search.

The query is set up to search within 500 miles of the user's location, but return the five closest results.