### PR TITLE
fixed bug that map wouldn't display if user didn't share location

### DIFF
--- a/assets/javascript/petfinder-api.js
+++ b/assets/javascript/petfinder-api.js
@@ -32,6 +32,11 @@ function onGeolocateError(error) {
   //   console.log("Timeout");
   // }
 
+  Latlong = {
+    latitude: null,
+    longitude: null
+  }
+
   searchForCats(35.7963914, -78.7044064);  //default coordinates
 }
 

--- a/map.html
+++ b/map.html
@@ -59,7 +59,9 @@
         geocoder.geocode({ address: address }, function(results, status) {
           if (status === "OK") {
             map.setCenter(results[0].geometry.location);
-            calcRoute();
+            if (LatLong.latitude !== null && LatLong.longitude !== null) {
+              calcRoute();
+            }
             var marker = new google.maps.Marker({
               map: map,
               position: results[0].geometry.location


### PR DESCRIPTION
If user declines to share their location, petfinder-api.js will now pass "null" values for lat and long and map.html will not call the calcRoute function if those values are null.